### PR TITLE
jags parallel: issues in executing chains in parallel

### DIFF
--- a/Matlab/fit_meta_d_mcmc.m
+++ b/Matlab/fit_meta_d_mcmc.m
@@ -385,5 +385,5 @@ fit.obs_HR2_rS2  = obs_HR2_rS2;
 fit.est_FAR2_rS2 = est_FAR2_rS2;
 fit.obs_FAR2_rS2 = obs_FAR2_rS2;
 
-cd(cwd);
+%cd(cwd);
 

--- a/Matlab/matjags.m
+++ b/Matlab/matjags.m
@@ -212,7 +212,7 @@ end
 
 % Do we use the Matlab parallel computing toolbox?
 if doParallel==1
-    numworkers = matlabpool('size');
+    numworkers = parpool('size');
     if (numworkers == 0)
         error( 'Matlab pool of workers not initialized. Use command "matlabpool open 7" for example to open up a pool of 7 workers' );
     end


### PR DESCRIPTION
1- matlabpool command does not work as intended. replaced by parpool
2- the cd command is disruptive to certain workflows (especially in parallel execution).

Signed-off-by: nidstigator <nadim.atiya@gmail.com>